### PR TITLE
Disable Homebrew's FetchContent trapping

### DIFF
--- a/keymapper.rb
+++ b/keymapper.rb
@@ -13,7 +13,13 @@ class Keymapper < Formula
   depends_on "asio" => :build
 
   def install
-    system "cmake", "-B", "build", *std_cmake_args
+    # Disables Homebrew's FetchContent trapping.
+    args = std_cmake_args
+    args += %W[
+      -DHOMEBREW_ALLOW_FETCHCONTENT=ON
+    ]
+
+    system "cmake", "-B", "build", *args
     system "cmake", "--build", "build", "-j", "4"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Homebrew recently disabled FetchContent for installing dependencies in Homebrew/brew#17075 and then the mechanism changed in Homebrew/brew#17310. Attempting to install keymapper now gives these errors:

```
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/homebrew/Library/Homebrew/shims/mac/super/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Git: /opt/homebrew/Library/Homebrew/shims/mac/super/git (found version "2.39.3 (Apple Git-146)")
CMake Error at /opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake:10 (message):
  Refusing to populate dependency 'asio' with FetchContent while building in
  Homebrew, please use a formula dependency or add a resource to the formula.
Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.29.3/share/cmake/Modules/FetchContent.cmake:2017:EVAL:1 (trap_fetchcontent_provider)
  /opt/homebrew/Cellar/cmake/3.29.3/share/cmake/Modules/FetchContent.cmake:2017 (cmake_language)
  CMakeLists.txt:276 (FetchContent_MakeAvailable)


-- Configuring incomplete, errors occurred!
```

This PR re-enables FetchContent so that asio can be installed by setting the `HOMEBREW_ALLOW_FETCHCONTENT=ON` option.